### PR TITLE
onSuccess Callback updated to work with custom callback URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,20 @@ export default function App() {
       console.log('Status URL:', statusUrl);
 
       await reclaimProofRequest.startSession({
-        onSuccess: async (proof: Proof) => {
-          console.log('Proof received:', proof);
-          setStatus('Proof received!');
-          setExtracted(JSON.stringify(proof.claimData.context));
-          setProofObject(JSON.stringify(proof, null, 2));
+        onSuccess: async (proof: Proof | string | undefined) => {
+          if (proof){
+            if (typeof proof === 'string') {
+              // When using a custom callback url, the proof is returned to the callback url and we get a message instead of a proof
+              console.log('SDK Message:', proof)
+              setExtracted(proof)
+            } else if (typeof proof !== 'string') {  
+              console.log('Proof received:', proof);
+              setExtracted(JSON.stringify(proof.claimData.context));
+            }
+            setStatus('Proof received!');
+            setProofObject(JSON.stringify(proof, null, 2));
+          }
+
         },
         onError: (error: Error) => {
           console.error('Error in proof generation:', error);

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -160,11 +160,20 @@ export default function App() {
 
       // Start the verification session
       await reclaimProofRequest.startSession({
-        onSuccess: async (proof: Proof) => {
-          console.log('Proof received:', proof);
-          setStatus('Proof received!');
-          setExtracted(JSON.stringify(proof.claimData.context));
-          setProofObject(JSON.stringify(proof, null, 2)); // Format the proof object
+        onSuccess: async (proof: Proof | string | undefined) => {
+          if (proof){
+            if (typeof proof === 'string') {
+              // When using a custom callback url, the proof is returned to the callback url and we get a message instead of a proof
+              console.log('SDK Message:', proof)
+              setExtracted(proof)
+            } else if (typeof proof !== 'string') {  
+              console.log('Proof received:', proof);
+              setExtracted(JSON.stringify(proof.claimData.context));
+            }
+            setStatus('Proof received!');
+            setProofObject(JSON.stringify(proof, null, 2)); // Format the proof object
+          }
+
         },
         onError: (error: Error) => {
           console.error('Error in proof generation:', error);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -45,3 +45,6 @@ export const GetAppCallbackUrlError = createErrorClass(
 export const GetRequestUrlError = createErrorClass('GetRequestUrlError');
 export const StatusUrlError = createErrorClass('StatusUrlError');
 export const ProofNotFoundError = createErrorClass('ProofNotFoundError');
+export const ProofSubmissionFailedError = createErrorClass(
+  'ProofSubmissionFailedError'
+);

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -38,7 +38,7 @@ export type StartSessionParams = {
   onError: OnError;
 };
 
-export type OnSuccess = (proof: Proof) => void;
+export type OnSuccess = (proof: Proof | string) => void;
 export type OnError = (error: Error) => void;
 
 export type ProofRequestOptions = {
@@ -66,6 +66,7 @@ export enum SessionStatus {
   PROOF_GENERATION_SUCCESS = 'PROOF_GENERATION_SUCCESS',
   PROOF_GENERATION_FAILED = 'PROOF_GENERATION_FAILED',
   PROOF_SUBMITTED = 'PROOF_SUBMITTED',
+  PROOF_SUBMISSION_FAILED = 'PROOF_SUBMISSION_FAILED',
   PROOF_MANUAL_VERIFICATION_SUBMITED = 'PROOF_MANUAL_VERIFICATION_SUBMITED',
 }
 
@@ -81,6 +82,7 @@ export type ProofPropertiesJSON = {
   timeStamp: string;
   appCallbackUrl?: string;
   options?: ProofRequestOptions;
+  sdkVersion: string;
 };
 
 export type TemplateData = {
@@ -94,6 +96,7 @@ export type TemplateData = {
   parameters: { [key: string]: string };
   redirectUrl: string;
   acceptAiProviders: boolean;
+  sdkVersion: string;
 };
 
 // Add the new StatusUrlResponse type


### PR DESCRIPTION
### Description
onSuccess callback now reflects that status for the custom callback url too. Once proof are successfully submitted on to custom callback url, we get a message in onSuccess callback to notify about it to the client.

### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).
