### PR TITLE
Added Support for Cascading Providers in the verifyProof method

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ export default function App() {
       console.log('Status URL:', statusUrl);
 
       await reclaimProofRequest.startSession({
-        onSuccess: async (proof: Proof | string | undefined) => {
+        onSuccess: async (proof: Proof | Proof[] | string | undefined) => {
           if (proof){
             if (typeof proof === 'string') {
               // When using a custom callback url, the proof is returned to the callback url and we get a message instead of a proof
@@ -133,7 +133,11 @@ export default function App() {
               setExtracted(proof)
             } else if (typeof proof !== 'string') {  
               console.log('Proof received:', proof);
-              setExtracted(JSON.stringify(proof.claimData.context));
+              if (Array.isArray(proof)) {
+                setExtracted(JSON.stringify(proof.map(p => p.claimData.context)))
+              } else {
+                setExtracted(JSON.stringify(proof.claimData.context));
+              }
             }
             setStatus('Proof received!');
             setProofObject(JSON.stringify(proof, null, 2));

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -160,15 +160,19 @@ export default function App() {
 
       // Start the verification session
       await reclaimProofRequest.startSession({
-        onSuccess: async (proof: Proof | string | undefined) => {
+        onSuccess: async (proof: Proof | Proof[] | string | undefined) => {
           if (proof){
             if (typeof proof === 'string') {
               // When using a custom callback url, the proof is returned to the callback url and we get a message instead of a proof
               console.log('SDK Message:', proof)
               setExtracted(proof)
             } else if (typeof proof !== 'string') {  
-              console.log('Proof received:', proof);
-              setExtracted(JSON.stringify(proof.claimData.context));
+              console.log('Proof received:', proof)
+              if (Array.isArray(proof)) {
+                setExtracted(JSON.stringify(proof.map(p => p.claimData.context)))
+              } else {
+                setExtracted(JSON.stringify(proof.claimData.context));
+              }
             }
             setStatus('Proof received!');
             setProofObject(JSON.stringify(proof, null, 2)); // Format the proof object

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -38,7 +38,7 @@ export type StartSessionParams = {
   onError: OnError;
 };
 
-export type OnSuccess = (proof: Proof | string) => void;
+export type OnSuccess = (proof: Proof | Proof[] | string) => void;
 export type OnError = (error: Error) => void;
 
 export type ProofRequestOptions = {


### PR DESCRIPTION
### Description
Adding Support for Cascading Providers for verify proof method to accept an array of Proofs

### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).
